### PR TITLE
move BASECAMP_NOMQTT define before include basecamp

### DIFF
--- a/esp32/doorsignEPD/doorsignEPD.ino
+++ b/esp32/doorsignEPD/doorsignEPD.ino
@@ -248,7 +248,7 @@ void loop() {
   if (production == true) {
 
     int SleepTime = iot.configuration.get("ImageWait").toInt();
-    esp_sleep_enable_timer_wakeup(FactorSeconds * SleepTime);
+    esp_sleep_enable_timer_wakeup(FactorSeconds * (uint64_t)SleepTime);
     Serial.println("Going to sleep now...");
     esp_deep_sleep_start();
   } else {

--- a/esp32/doorsignEPD/doorsignEPD.ino
+++ b/esp32/doorsignEPD/doorsignEPD.ino
@@ -1,11 +1,11 @@
 #define DEBUG 1
+#define BASECAMP_NOMQTT
 #include <Basecamp.hpp>
 
 //Define your display type here: 2.9, 4.2 (bw and bwr) or 7.5 (bw or bwr) inches are supported:
 #define DISPLAY_TYPE '4.2bwr'
 
 #define FactorSeconds 1000000LL
-#define BASECAMP_NOMQTT
 
 Basecamp iot;
 #include <GxEPD.h>


### PR DESCRIPTION
Sollte das BASECAMP_NOMQTT nicht vor dem #include <Basecamp.hpp> stehen?