### PR TITLE
Set the sleep times by the server

### DIFF
--- a/esp32/doorsignEPD/doorsignEPD.ino
+++ b/esp32/doorsignEPD/doorsignEPD.ino
@@ -16,6 +16,14 @@
 
 #define FactorSeconds 1000000LL
 #define BASECAMP_NOMQTT
+
+// This is the upper limit for the sleep time set by the server to prevent accidentally letting the display sleep for several days
+#define MAX_SLEEP_TIME (60*60*24)
+
+// Encrypted setup WiFi network
+//Basecamp iot{Basecamp::SetupModeWifiEncryption::secured};
+
+// Unencrypted setup WiFi network (default)
 Basecamp iot;
 AsyncClient client;
 
@@ -26,6 +34,9 @@ volatile bool requestDoneInPeriod = false;            //* We already received da
 bool connection = false;                              //* WiFi connection established
 bool production = false;                              //* We are in production mode and will go to deep sleep
 bool setupMode  = false;                              //* Setup mode: The web interface has to be accessible. Not going to deep sleep
+
+String sleepIntervalHeader = "X-sleepInterval:";      //* Name of the header for the sleep interval
+long   sleepIntervalSetbyHeader = 0;                  //* Changed if the sleep interval is set by the server via the header
 
 #include <GxEPD.h>
 
@@ -263,6 +274,24 @@ void onDataHandler(void *r, AsyncClient *client, void *data, size_t len){
       production = true;
     }
     Serial.println(String("ProductionMode: ") + production);
+
+    // Let the user set the sleep interval via a HTTP-header
+    if (header.indexOf(sleepIntervalHeader) > 0){
+      int sleepStartIndex = header.indexOf(sleepIntervalHeader) + sleepIntervalHeader.length();
+      int sleepStopIndex = header.indexOf("\r\n", sleepStartIndex);
+      if (sleepStopIndex < 0){
+        // End of header, use length as delimiter
+        sleepStopIndex = endHeader;
+      }
+
+      // toInt() sets sleepIntervalSetbyHeader to zero in case of errors during the conversion
+      sleepIntervalSetbyHeader = header.substring(sleepStartIndex, sleepStopIndex).toInt();
+      if (sleepIntervalSetbyHeader > MAX_SLEEP_TIME){
+        Serial.println("Too long sleep time. Limiting...");
+        sleepIntervalSetbyHeader = MAX_SLEEP_TIME;
+      }
+      
+    }
     
     // Handle remaining data bytes. 4 bytes for \r\n\r\n separation
     drawPixels((char*)data+endHeader+4, len-endHeader-4, true);
@@ -366,8 +395,14 @@ void loop() {
       if (tcpClientConnected) Serial.println("Ongoing connection");
       if (setupMode) Serial.println("In setup mode");
     } else {
-      int SleepTime = iot.configuration.get("ImageWait").toInt();
-      esp_sleep_enable_timer_wakeup(FactorSeconds * (uint64_t)SleepTime);
+      if (sleepIntervalSetbyHeader > 0){
+        Serial.println(String("Using sleep interval set by header \"") + sleepIntervalHeader + "\":" + sleepIntervalSetbyHeader);
+        esp_sleep_enable_timer_wakeup(FactorSeconds * (uint64_t)sleepIntervalSetbyHeader);
+      } else {
+        // No sleep time set via header or invalid value
+        int SleepTime = iot.configuration.get("ImageWait").toInt();
+        esp_sleep_enable_timer_wakeup(FactorSeconds * (uint64_t)SleepTime);
+      }
       Serial.println("Going to deep sleep now...");
       esp_deep_sleep_start();
     }

--- a/server/index.php
+++ b/server/index.php
@@ -4,6 +4,9 @@
 //To stop productionMode (no deep sleep, web config), set http-header X-productionMode: false
 #header("X-productionMode: false");
 
+// Set the sleep interval for the doorsigns via the server
+#header("X-sleepInterval: 60 ");
+
 error_reporting('E_ERROR');
 # Supported displays:
 # 1.54 inches: https://www.waveshare.com/wiki/1.54inch_e-Paper_Module
@@ -64,12 +67,7 @@ if(strlen($_GET['scale']) AND is_numeric($_GET['scale'])){
 
 $displayType = $_GET['display'];
 if(!isset(DISPLAYS[$displayType])){
-    echo ("Not a valid display size. <br />");
-    echo ("display=[");
-    foreach (array_keys(DISPLAYS) as $display_key){
-        echo ($display_key.", ");
-    }
-    echo ("]");
+    echo ("Not a valid display size.");
     exit;
 }
 

--- a/server/index.php
+++ b/server/index.php
@@ -67,7 +67,12 @@ if(strlen($_GET['scale']) AND is_numeric($_GET['scale'])){
 
 $displayType = $_GET['display'];
 if(!isset(DISPLAYS[$displayType])){
-    echo ("Not a valid display size.");
+    echo ("Not a valid display size. <br />");
+    echo ("display=[");
+    foreach (array_keys(DISPLAYS) as $display_key){
+        echo ($display_key.", ");
+    }
+    echo ("]");
     exit;
 }
 


### PR DESCRIPTION
This PR allows to set the sleep times dynamically by the server. It addresses #11 .

* `header("X-sleepInterval: 60 ");` : Let the node sleep for 60 seconds
* `header("X-sleepInterval: 123 ");` : Let the node sleep for 123 seconds

An upper limit of one day (60 * 60 * 24 seconds, `MAX_SLEEP_TIME`) is set to prevent accidentally letting the node sleep longer than intended.