### PR TITLE
Update doorsignEPD.ino

### DIFF
--- a/esp32/doorsignEPD/doorsignEPD.ino
+++ b/esp32/doorsignEPD/doorsignEPD.ino
@@ -407,6 +407,11 @@ void loop() {
         int SleepTime = iot.configuration.get("ImageWait").toInt();
         esp_sleep_enable_timer_wakeup(FactorSeconds * (uint64_t)SleepTime);
       }
+      /**
+       *  Allow for external triggering of display refresh using GPIO 15 high.
+       */
+      Serial.println("Setting GPIO 15 for external wakeup...");
+      esp_sleep_enable_ext0_wakeup(GPIO_NUM_15, 1); //1 = High, 0 = Low
       Serial.println("Going to deep sleep now...");
       Serial.flush();
       esp_deep_sleep_start();


### PR DESCRIPTION
GPIO 15 is used for external triggering of display refresh. I'm using am WeMos D1 mini with ESPEasy software to do so (http://<wemos_ip>/control?cmd=Pulse,13,1,100). 
Since I am a arduino (and github) beginner please excuse my poor implementation if there are more elegant ways. But at least it's working.