### PR TITLE
Fix linker issues with GxEPD and GxIO

### DIFF
--- a/esp32/doorsignEPD/doorsignEPD.ino
+++ b/esp32/doorsignEPD/doorsignEPD.ino
@@ -41,37 +41,36 @@ long   sleepIntervalSetbyHeader = 0;                  //* Changed if the sleep i
 #include <GxEPD.h>
 
 #if DISPLAY_TYPE == '1.5'
-#include <GxGDEP015OC1/GxGDEP015OC1.cpp>      // 1.54" b/w
+#include <GxGDEP015OC1/GxGDEP015OC1.h>      // 1.54" b/w
 bool hasRed = false;
 String displayType = "1.5";
 #endif
 #if DISPLAY_TYPE == '2.9'
-#include <GxGDEH029A1/GxGDEH029A1.cpp>      // 2.9" b/w
+#include <GxGDEH029A1/GxGDEH029A1.h>      // 2.9" b/w
 bool hasRed = false;
 String displayType = "2.9";
 #endif
 #if DISPLAY_TYPE == '4.2'
-#include <GxGDEW042T2/GxGDEW042T2.cpp>      // 4.2" b/w
+#include <GxGDEW042T2/GxGDEW042T2.h>      // 4.2" b/w
 bool hasRed = false;
 String displayType = "4.2";
 #endif
 #if DISPLAY_TYPE == '4.2bwr'
-#include <GxGDEW042Z15/GxGDEW042Z15.cpp>       // 4.2" b/w/r
+#include <GxGDEW042Z15/GxGDEW042Z15.h>       // 4.2" b/w/r
 bool hasRed = true;
 String displayType = "4.2bwr";
 #endif
 #if DISPLAY_TYPE == '7.5'
-#include <GxGDEW075T8/GxGDEW075T8.cpp>      // 7.5" b/w
+#include <GxGDEW075T8/GxGDEW075T8.h>      // 7.5" b/w
 bool hasRed = false;
 String displayType = "7.5";
 #endif
 #if DISPLAY_TYPE == '7.5bwr'
-#include <GxGDEW075Z09/GxGDEW075Z09.cpp>      // 7.5" b/w/r
+#include <GxGDEW075Z09/GxGDEW075Z09.h>      // 7.5" b/w/r
 bool hasRed = true;
 String displayType = "7.5bwr";
 #endif
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
 #include <Fonts/FreeMonoBold9pt7b.h>
 
 GxIO_Class io(SPI, CHIP_SELECT, 17, 16);


### PR DESCRIPTION
Newer GxEPD version links needed cpp files automatically:
- Unneccessary include removed (GxIO.cpp)
- Includes for display types changed to according header files instead of cpp